### PR TITLE
fix gpio callback registration

### DIFF
--- a/device.nut
+++ b/device.nut
@@ -344,7 +344,7 @@ class SX150x{
  
     //configure which callback should be called for each pin transition
     function setCallback(gpio, callback){
-        _callbacks.insert(gpio,callback);
+        _callbacks[gpio] = callback;
     }
  
     function callback(){


### PR DESCRIPTION
setting a callback for a gpio pin X would shift callback assignments for all gpio pins > X

the main loop sets/unsets gpio 8 (nfc) on every iteration. a callback registration for pin 11 would gradually move to higher pins and eventually pushed off the callbacks array.
